### PR TITLE
Add MTG card search using Scryfall API

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,6 +171,12 @@
       alt="MTG Artwork" 
       onclick="openFullscreen()" />
   </div>
+  <h2>MTG-Kartensuche (Scryfall API)</h2>
+<div id="cardSearchSection">
+  <input type="text" id="cardSearchInput" placeholder="Kartennamen eingeben..." style="width: 100%; padding: 10px; font-size: 16px;" />
+  <button onclick="searchCard()" style="margin-top: 10px;">Suche starten</button>
+  <div id="cardResult" style="margin-top: 20px;"></div>
+</div>
 </div>
 
 <!-- Vollbild-Overlay, zunächst versteckt -->
@@ -182,6 +188,45 @@
 </div>
 
 <script>
+    async function searchCard() {
+    const query = document.getElementById('cardSearchInput').value.trim();
+    const resultDiv = document.getElementById('cardResult');
+    resultDiv.innerHTML = '';
+
+    if (!query) {
+      resultDiv.innerHTML = '<p>Bitte gib einen Kartennamen ein.</p>';
+      return;
+    }
+
+    try {
+      const response = await fetch(`https://api.scryfall.com/cards/search?q=${encodeURIComponent(query)}`, {
+        headers: {
+          'Accept': 'application/json'
+        }
+      });
+
+      const data = await response.json();
+
+      if (!data || !data.data || data.data.length === 0) {
+        resultDiv.innerHTML = '<p>Keine Karte gefunden.</p>';
+        return;
+      }
+
+      const card = data.data[0]; // erste gefundene Karte
+      const imageUrl = card.image_uris?.normal || card.card_faces?.[0]?.image_uris?.normal || '';
+
+      resultDiv.innerHTML = `
+        <p><strong>${card.name}</strong> (${card.set_name})</p>
+        ${imageUrl ? `<img src="${imageUrl}" alt="${card.name}" style="max-width: 100%; border-radius: 8px;" />` : ''}
+        <p>${card.type_line}</p>
+        <p>${card.oracle_text?.replace(/\n/g, '<br>') || ''}</p>
+        <p><small>Illustration: ${card.artist} &mdash; &copy; Wizards of the Coast</small></p>
+      `;
+    } catch (err) {
+      resultDiv.innerHTML = '<p>Fehler bei der Suche. Bitte später erneut versuchen.</p>';
+      console.error(err);
+    }
+  }
   // Standardanzahl Länder in einem 40-Karten-Deck
   const TOTAL_LANDS_40 = 17;
 


### PR DESCRIPTION
Adds a search input for Magic: The Gathering cards using the Scryfall public API at the bottom of the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Magic: The Gathering card search section using the Scryfall API, allowing users to search for cards by name and view detailed card information, including images and descriptions.
- **Bug Fixes**
  - Improved error handling for failed searches and empty input, with clear user feedback messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->